### PR TITLE
Added support of aws provider more than 3.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,10 +27,10 @@ resource "aws_route53_record" "this" {
   count = var.module_enabled ? var.alternative_domains_count + 1 : 0
 
   # count   = "${ var.module_enabled && var.aws_issued_cert && ! var.imported_cert ? length(aws_acm_certificate.aws.0.domain_validation_options) : 0 }"
-  name    = aws_acm_certificate.aws.0.domain_validation_options[count.index]["resource_record_name"]
-  type    = aws_acm_certificate.aws.0.domain_validation_options[count.index]["resource_record_type"]
+  name    = tolist(aws_acm_certificate.aws.0.domain_validation_options)[count.index]["resource_record_name"]
+  type    = tolist(aws_acm_certificate.aws.0.domain_validation_options)[count.index]["resource_record_type"]
   zone_id = var.zone_id
-  records = [aws_acm_certificate.aws.0.domain_validation_options[count.index]["resource_record_value"]]
+  records = [tolist(aws_acm_certificate.aws.0.domain_validation_options)[count.index]["resource_record_value"]]
   ttl     = 60
 }
 

--- a/test/main.tf
+++ b/test/main.tf
@@ -8,7 +8,7 @@ module "aws-cert" {
   #  module_enabled = "false"
 
   domain                    = "*.example.com"
-  zone_id                   = "${var.zone_id}"
+  zone_id                   = var.zone_id
   alternative_domains_count = 2
   alternative_domains = [
     "*.first.example.com",


### PR DESCRIPTION
In AWS provider https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.0.0
we have next breaking change:
resource/aws_acm_certificate: domain_validation_options attribute changed from list to set
https://github.com/terraform-providers/terraform-provider-aws/issues/14199